### PR TITLE
Fix support for downlevel DB2 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@ The LoopBack DB2 connector supports:
 
 - All [CRUD operations](https://docs.strongloop.com/display/LB/Creating%2C+updating%2C+and+deleting+data).
 - [Queries](https://docs.strongloop.com/display/LB/Querying+data) with fields, limit, order, skip and where filters.
-
-The following features are not yet implemented:
-
-- Model discovery.
-- Auto-migration and update.
+- All supported DB2 LUW versions as well as dashDB.  Note for dashDB set supportDashDB in the loopback datasource definition.  Column organized tables are not supported.
 
 ## Installation
 
@@ -61,6 +57,7 @@ password       | String  | DB2 password associated with the username above
 hostname       | String  | DB2 server hostname or IP address
 port           | String  | DB2 server TCP port number
 useLimitOffset | Boolean | LIMIT and OFFSET must be configured on the DB2 server before use (compatibility mode)
+supportDashDB  | Boolean | Create ROW ORGANIZED tables to support dashDB.
 
 
 Alternatively, you can create and configure the data source in JavaScript code.

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -39,6 +39,7 @@ function DB2(settings) {
   this.portnumber = settings.port;
   this.protocol = (settings.protocol || 'TCPIP');
   this.supportColumnStore = (settings.supportColumnStore || false);
+  this.supportDashDB = (settings.supportDashDB || false);
 
   this.connStr =
     'DRIVER={DB2}' +
@@ -526,10 +527,16 @@ DB2.prototype.createTable = function(model, cb) {
   if (self.supportColumnStore && self.supportColumnStore === true) {
     return cb(new Error('Column organized tables are not ' +
                         'currently supported'));
-  } else {
+  } else if (self.supportDashDB) {
     tasks.push(function(callback) {
       var sql = 'CREATE TABLE ' + tableSchema + '.' + tableName +
           ' (' + columnDefinitions + ') ORGANIZE BY ROW;';
+      self.execute(sql, callback);
+    });
+  } else {
+    tasks.push(function(callback) {
+      var sql = 'CREATE TABLE ' + tableSchema + '.' + tableName +
+          ' (' + columnDefinitions + ');';
       self.execute(sql, callback);
     });
   }

--- a/test/init.js
+++ b/test/init.js
@@ -9,7 +9,8 @@ var config = {
   port: process.env.DB2_PORTNUM || 60000,
   database: process.env.DB2_DATABASE || 'testdb',
   schema: process.env.DB2_SCHEMA || 'STRONGLOOP',
-  supportColumnStore: false,
+  supportColumnStore: process.env.DB2_USECOLUMNSTORE || false,
+  supportDashDB: process.env.DB2_SUPPORT_DASHDB || false,
 };
 
 global.config = config;

--- a/test/tables.sql
+++ b/test/tables.sql
@@ -7,17 +7,17 @@ DROP TABLE LOCALUSER3;
   CREATE TABLE "LOCALUSER1"
    (    "ID" VARCHAR(20) NOT NULL,
         "USERNAME" VARCHAR(250)
-   ) ORGANIZE BY ROW;
+   );
 
   CREATE TABLE "LOCALUSER2"
    (    "ID" VARCHAR(20) NOT NULL,
         "USERNAME" VARCHAR(250)
-   ) ORGANIZE BY ROW;
+   );
 
   CREATE TABLE "LOCALUSER3"
    (    "ID" VARCHAR(20) NOT NULL,
         "USERNAME" VARCHAR(250)
-   ) ORGANIZE BY ROW;
+   );
 
 SET CURRENT SCHEMA = STRONGLOOP;
 
@@ -51,7 +51,7 @@ DROP TABLE RESERVATION;
 	"STATUS" VARCHAR(1024),
 	"CREATED" DATE,
 	"LASTUPDATED" DATE
-   ) ORGANIZE BY ROW;
+   );
 
 --------------------------------------------------------
 --  DDL for Table INVENTORY
@@ -63,7 +63,7 @@ DROP TABLE RESERVATION;
 	"LOCATION_ID" VARCHAR(20),
 	"AVAILABLE" INTEGER,
 	"TOTAL" INTEGER
-   ) ORGANIZE BY ROW ;
+   ) ;
 
 
 -- CREATE SEQUENCE INVENTORY_ID_SEQ START WITH 1 INCREMENT BY 1 NOMAXVALUE;
@@ -83,7 +83,7 @@ DROP TABLE RESERVATION;
 	"ZIPCODE" VARCHAR(16),
 	"NAME" VARCHAR(32),
 	"GEO" VARCHAR(1024)
-   ) ORGANIZE BY ROW;
+   );
 
 --------------------------------------------------------
 --  DDL for Table PRODUCT
@@ -97,7 +97,7 @@ DROP TABLE RESERVATION;
 	"ROUNDS" INTEGER,
 	"EXTRAS" VARCHAR(64),
 	"FIRE_MODES" VARCHAR(64)
-   ) ORGANIZE BY ROW;
+   );
 
 --------------------------------------------------------
 --  DDL for Table RESERVATION
@@ -113,7 +113,7 @@ DROP TABLE RESERVATION;
 	"RESERVE_DATE" DATE,
 	"PICKUP_DATE" DATE,
 	"RETURN_DATE" DATE
-   ) ORGANIZE BY ROW;
+   );
 
 --------------------------------------------------------
 --  DDL for Table SESSION
@@ -123,7 +123,7 @@ DROP TABLE RESERVATION;
    (	"ID" VARCHAR(64) NOT NULL,
 	"UID" VARCHAR(1024),
 	"TTL" INT
-   ) ORGANIZE BY ROW;
+   );
 
 -- REM INSERTING into CUSTOMER
 -- SET DEFINE OFF;


### PR DESCRIPTION
Previous contribution broke DB2 versions prior to V10.5 by adding the ORGANIZE BY ROW option to createTable.  This can ONLY be done for V10.5 and DashDB so this contribution will add flags to support DashDB by ENV variable DB2_SUPPORT_DASHDB or loopback datasource configuration property of supportDashDB.  Note that tests will only successfully run against dashDB if the DB2_SCHEMA is set to the dashDB user name as some tests otherwise require SQL execution of IMPLICIT SCHEMA CREATE which is not allow in DashDB.