### PR TITLE
Add DB2 for z/OS support and a fix for issues #28

### DIFF
--- a/lib/db2.js
+++ b/lib/db2.js
@@ -7,6 +7,7 @@ var Driver = require('ibm_db');
 var util = require('util');
 var debug = require('debug')('loopback:connector:db2');
 var async = require('async');
+var Transaction = require('loopback-connector').Transaction;
 
 /**
  * Initialize the DB2 connector for the given data source
@@ -41,6 +42,7 @@ function DB2(settings) {
   this.protocol = (settings.protocol || 'TCPIP');
   this.supportColumnStore = (settings.supportColumnStore || false);
   this.supportDashDB = (settings.supportDashDB || false);
+  this.isDB2z = (settings.supportDB2z || false);
 
   var dsn = settings.dsn;
   if (dsn) {
@@ -97,7 +99,7 @@ function parseDSN(dsn) {
 util.inherits(DB2, SqlConnector);
 
 function testConnection(conn) {
-  var sql = 'SELECT COUNT(*) AS COUNT FROM SYSCAT.TABLES';
+  var sql = 'SELECT COUNT(*) AS COUNT FROM SYSIBM.SYSTABLES';
   var rows = conn.querySync(sql, null);
 
   if (rows.length > 0 && rows[0]['COUNT'] > 0) {
@@ -442,81 +444,95 @@ DB2.prototype.update = function(model, where, data, options, cb) {
 DB2.prototype.updateOrCreate = DB2.prototype.save =
   function(model, data, options, callback) {
     var self = this;
-    var fields = self.buildFields(model, data);
     var id = self.idName(model);
-    var sql = new ParameterizedSQL('MERGE INTO ' +
-                                   self.schema.toUpperCase() + '.' +
-                                   self.tableEscaped(model));
-    var columnValues = fields.columnValues;
-    var fieldNames = fields.names;
-    var setValues = [];
+    var stmt;
+    var tableName = self.tableEscaped(model);
+    var meta = {};
 
-    var definition = self.getModelDefinition(model);
+    function executeWithConnection(connection, cb) {
+      // Execution for updateOrCreate requires running two
+      // separate SQL statements.  The second depends on the
+      // result of the first.
+      var countStmt = new ParameterizedSQL('SELECT COUNT(*) AS CNT FROM ');
+      countStmt.merge(tableName);
+      countStmt.merge(self.buildWhere(data));
 
-    if (fieldNames.length) {
-      sql.merge('AS MT(');
+      connection.query(countStmt.sql, countStmt.params,
+        function(err, countData) {
+          if (err) {
+            return cb(err);
+          }
 
-      Object.keys(definition.properties).forEach(function(prop) {
-        setValues.push(new ParameterizedSQL(self.columnEscaped(model, prop)));
-      });
+          if (countData[0]['CNT'] > 0) {
+            stmt = self.buildUpdate(model, data.id, data);
+          } else {
+            stmt = self.buildInsert(model, data);
+          }
 
-      var columns = ParameterizedSQL.join(setValues, ',');
-      sql.merge(columns);
-      sql.merge(')');
-      sql.merge('USING (SELECT * FROM TABLE( VALUES(');
+          connection.query(stmt.sql, stmt.params, function(err, sData) {
+            if (err) {
+              return cb(err);
+            }
 
-      setValues = [];
-      for (var i = 0, n = fields.names.length; i < n; i++) {
-        setValues.push(new ParameterizedSQL('CAST (' + columnValues[i].sql +
-          ' AS ' +
-          self.buildColumnType(fields.properties[i]) + ')',
-          columnValues[i].params));
+            if (countData[0]['CNT'] > 0) {
+              meta.isNewInstance = false;
+              cb(null, data, meta);
+            } else {
+              stmt = 'SELECT MAX(' + id + ') as id FROM ' + tableName;
+              connection.query(stmt, null, function(err, info) {
+                if (err) {
+                  return cb(err);
+                }
+                data.id = info[0]['CNT'];
+                cb(null, data, meta);
+              });
+            }
+          });
+        });
+    };
 
-        if (i < (n - 1))
-          setValues[i].sql = setValues[i].sql + ',';
-      }
-
-      sql.merge(setValues);
-      sql.merge('))) AS VT(' + fieldNames.join(',') + ')');
-      sql.merge('ON');
-      sql.merge('(MT.\"' + id + '\" = VT.\"' + id + '\")');
-      sql.merge('WHEN NOT MATCHED THEN INSERT (' +
-      fieldNames.join(',') + ')');
-
-      var values = ParameterizedSQL.join(columnValues, ',');
-      values.sql = 'VALUES(' + values.sql + ')';
-      sql.merge(values);
+    if (options.transaction) {
+      executeWithConnection(options.transaction.connection,
+        function(err, data, meta) {
+          if (err) {
+            return callback && callback(err);
+          } else {
+            return callback && callback(null, data, meta);
+          }
+        });
     } else {
-      sql.merge(self.buildInsertDefaultValues(model, data, options));
+      self.beginTransaction(Transaction.READ_COMMITTED, function(err, conn) {
+        // self.client.open(self.connStr, function(err, conn) {
+        if (err) {
+          return callback && callback(err);
+        }
+
+        // conn.beginTransaction(function(err) {
+        if (err) {
+          return callback && callback(err);
+        }
+
+        executeWithConnection(conn, function(err, data, meta) {
+          if (err) {
+            conn.rollbackTransaction(function(err) {
+              conn.close(function() {});
+              return callback && callback(err);
+            });
+          } else {
+            options.transaction = undefined;
+            conn.commitTransaction(function(err) {
+              if (err) {
+                return callback && callback(err);
+              }
+
+              conn.close(function() {});
+              return callback && callback(null, data, meta);
+            });
+          }
+        });
+        // });
+      });
     }
-
-    sql.merge('WHEN MATCHED THEN UPDATE SET');
-
-    setValues = [];
-    for (i = 0, n = fields.names.length; i < n; i++) {
-      if (!fields.properties[i].id) {
-        setValues.push(new ParameterizedSQL(fields.names[i] + '=' +
-          '(' + columnValues[i].sql + ')', columnValues[i].params));
-      }
-    }
-
-    sql.merge(ParameterizedSQL.join(setValues, ','));
-
-    self.execute(sql.sql, sql.params, options, function(err, info) {
-      if (!err && info && info.insertId) {
-        data.id = info.insertId;
-      }
-      var meta = {};
-      if (info) {
-        // When using the INSERT ... ON DUPLICATE KEY UPDATE statement,
-        // the returned value is as follows:
-        // 1 for each successful INSERT.
-        // 2 for each successful UPDATE.
-        meta.isNewInstance = (info.affectedRows === 1);
-      }
-
-      callback(err, data, meta);
-    });
   };
 
 /**
@@ -575,11 +591,17 @@ DB2.prototype.getCountForAffectedRows = function(model, info) {
  */
 DB2.prototype.dropTable = function(model, cb) {
   var self = this;
-  var sql =
-      'BEGIN\nDECLARE CONTINUE HANDLER FOR SQLSTATE \'42704\'\n' +
-      'BEGIN END;\nEXECUTE IMMEDIATE \'DROP TABLE ' +
-      self.schema + '.' + self.tableEscaped(model) + '\';\nEND';
-  self.execute(sql, cb);
+  var dropStmt = 'DROP TABLE ' + self.schema + '.' +
+    self.tableEscaped(model);
+
+  self.execute(dropStmt, null, null, function(err, countData) {
+    if (err) {
+      if (!err.toString().includes('42704')) {
+        return cb && cb(err);
+      }
+    }
+    return cb && cb(err);
+  });
 };
 
 DB2.prototype.createTable = function(model, cb) {
@@ -706,7 +728,7 @@ DB2.prototype.buildColumnDefinition = function(model, prop) {
       ' AS IDENTITY (START WITH 1 INCREMENT BY 1)';
   }
   var line = this.columnDataType(model, prop) + ' ' +
-      (this.isNullable(p) ? 'NULL' : 'NOT NULL');
+      (this.isNullable(p) ? '' : 'NOT NULL');
   return line;
 };
 

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -58,20 +58,20 @@ function mixinDiscovery(DB2, db2) {
 
     if (options.all && !schema) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
-        ' tabname AS "name", tabschema AS "owner", property' +
+        ' tabname AS "name", tabschema AS "owner", property as "property"' +
         ' FROM syscat.tables where substr(property,20,1) NOT LIKE \'Y\'',
         'table_schema, table_name', options);
     } else if (schema) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
-        ' tabname AS "name", tabschema AS "schema", property' +
+        ' tabname AS "name", tabschema AS "schema", property as "property"' +
         ' FROM syscat.tables' +
-        ' WHERE tabschema="' + schema + '" AND' +
+        ' WHERE tabschema=\'' + schema + '\' AND' +
         ' SUBSTR(property, 20, 1) NOT LIKE \'Y\'',
         'table_schema, table_name', options);
     } else {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
         ' tabname AS "name", ' +
-        ' tabschema AS "owner", property FROM syscat.tables' +
+        ' tabschema AS "owner", property as "property" FROM syscat.tables' +
         ' WHERE tabschema = CURRENT USER AND' +
         ' SUBSTR(property, 20, 1) NOT LIKE \'Y\'',
         'tabname', options);
@@ -103,7 +103,7 @@ function mixinDiscovery(DB2, db2) {
           ' tabname AS "name",' +
           ' tabschema AS "owner"' +
           ' FROM syscat.tables' +
-          ' WHERE tabschema="' + schema + '"',
+          ' WHERE tabschema=\'' + schema + '\'',
           'tabschema, tabname', options);
       } else {
         sqlViews = paginateSQL('SELECT \'view\' AS "type",' +
@@ -124,12 +124,14 @@ function mixinDiscovery(DB2, db2) {
    * @param {Function} [cb] The callback function
    */
   DB2.prototype.discoverDatabaseSchemas = function(cb) {
+    var self = this;
     var options = {};
-    // if (!cb && typeof options === 'function') {
-    //   cb = options;
-    //   options = {};
-    // }
-    // options = options || {};
+    if (self.isDB2z) {
+      process.nextTick(function() {
+        return cb(Error('Function not supported'));
+      });
+    }
+
     this.execute(querySchemas(options), cb);
   };
 
@@ -140,13 +142,19 @@ function mixinDiscovery(DB2, db2) {
    * @param {Function} [cb] The callback function
    */
   DB2.prototype.discoverModelDefinitions = function(options, cb) {
+    var self = this;
+    if (self.isDB2z) {
+      process.nextTick(function() {
+        return cb(Error('Function not supported'));
+      });
+    }
+
     if (!cb && typeof options === 'function') {
       cb = options;
       options = {};
     }
     options = options || {};
 
-    var self = this;
     var calls = [function(callback) {
       self.execute(queryTables(options), callback);
     }];
@@ -233,6 +241,7 @@ function mixinDiscovery(DB2, db2) {
         (table ? ' WHERE tabname="' + table + '"' : ''),
         'tabname, ordinal_position', {});
     }
+
     return sql;
   }
 
@@ -246,6 +255,12 @@ function mixinDiscovery(DB2, db2) {
    */
   DB2.prototype.discoverModelProperties = function(table, options, cb) {
     var self = this;
+    if (self.isDB2z) {
+      process.nextTick(function() {
+        return cb(Error('Function not supported'));
+      });
+    }
+
     var args = getArgs(table, options, cb);
     var schema = args.schema;
     if (!schema) {
@@ -296,6 +311,7 @@ function mixinDiscovery(DB2, db2) {
     }
     sql += ' ORDER BY' +
       ' tabschema, constname, tabname, colseq';
+
     return sql;
   }
 
@@ -307,6 +323,13 @@ function mixinDiscovery(DB2, db2) {
    * @param {Function} [cb] The callback function
    */
   DB2.prototype.discoverPrimaryKeys = function(table, options, cb) {
+    var self = this;
+    if (self.isDB2z) {
+      process.nextTick(function() {
+        return cb(Error('Function not supported'));
+      });
+    }
+
     var args = getArgs(table, options, cb);
     var schema = args.schema;
     if (!schema) {
@@ -333,8 +356,6 @@ function mixinDiscovery(DB2, db2) {
       'SELECT tabschema AS "fkOwner",' +
       ' constname AS "fkName",' +
       ' tabname AS "fkTableName",' +
-      // ' colname AS "fkColumnName",' +
-      // ' colseq AS "keySeq",' +
       ' reftabschema AS "pkOwner", \'PRIMARY\' AS "pkName",' +
       ' reftabname AS "pkTableName",' +
       ' refkeyname AS "pkColumnName"' +
@@ -349,6 +370,7 @@ function mixinDiscovery(DB2, db2) {
         sql += ' AND tabname LIKE \'"' + table + '\'';
       }
     }
+
     return sql;
   }
 
@@ -360,6 +382,13 @@ function mixinDiscovery(DB2, db2) {
    * @param {Function} [cb] The callback function
    */
   DB2.prototype.discoverForeignKeys = function(table, options, cb) {
+    var self = this;
+    if (self.isDB2z) {
+      process.nextTick(function() {
+        return cb(Error('Function not supported'));
+      });
+    }
+
     var args = getArgs(table, options, cb);
     var schema = args.schema;
     if (!schema) {
@@ -388,7 +417,6 @@ function mixinDiscovery(DB2, db2) {
       ' a.tabschema AS "fkOwner",' +
       ' a.tabname AS "fkTableName",' +
       ' a.colname AS "fkColumnName",' +
-      // ' a.ordinal_position AS "keySeq",' +
       ' NULL AS "pkName",' +
       ' a.referenced_table_schema AS "pkOwner",' +
       ' a.referenced_table_name AS "pkTableName",' +
@@ -414,6 +442,13 @@ function mixinDiscovery(DB2, db2) {
    * @param {Function} [cb] The callback function
    */
   DB2.prototype.discoverExportedForeignKeys = function(table, options, cb) {
+    var self = this;
+    if (self.isDB2z) {
+      process.nextTick(function() {
+        return cb(Error('Function not supported'));
+      });
+    }
+
     var args = getArgs(table, options, cb);
     var schema = args.schema;
     if (!schema) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -36,7 +36,18 @@ module.exports = function(DB2) {
         if (err) {
           return done(err);
         } else {
-          if (fields.length) {
+          if (self.isDB2z) {
+            // For DB2 on z/OS we need to destroy the model and
+            // recreate because we can't get all the data require
+            // to determine if the model is valid.
+            self.dropTable(model, function(err, cnt) {
+              if (err) {
+                return done(Error(err));
+              }
+
+              self.createTable(model, done);
+            });
+          } else if (fields.length) {
             self.alterTable(model, fields, indexes, done);
           } else {
             self.createTable(model, done);
@@ -53,27 +64,44 @@ module.exports = function(DB2) {
    */
   DB2.prototype.getTableStatus = function(model, cb) {
     var self = this;
-    var sql = 'SELECT COLNAME AS NAME, TYPENAME AS DATATYPE, ' +
-      'COLNO, LENGTH AS DATALENGTH, NULLS FROM SYSCAT.COLUMNS ' +
-      'WHERE TABNAME LIKE \'' +
-      self.table(model) + '\' ' +
-      'AND TABSCHEMA LIKE \'' +
-      self.schema + '\'' +
-      ' ORDER BY COLNO';
+    var columnSQL;
+    var indexSQL;
 
-    self.execute(sql, function(err, tableInfo) {
+    if (self.isDB2z) {
+      columnSQL = 'SELECT NAME, COLTYPE AS DATATYPE, COLNO, ' +
+        'LENGTH AS DATALENGTH, NULLS FROM SYSIBM.SYSCOLUMNS WHERE ' +
+        'TBNAME LIKE \'' + self.table(model) + '\' ' +
+        'AND TBCREATOR LIKE \'' + self.schema + '\' ' +
+        'ORDER BY COLNO';
+    } else {
+      columnSQL = 'SELECT COLNAME AS NAME, TYPENAME AS DATATYPE, ' +
+        'COLNO, LENGTH AS DATALENGTH, NULLS FROM SYSCAT.COLUMNS ' +
+        'WHERE TABNAME LIKE \'' +
+        self.table(model) + '\' ' +
+        'AND TABSCHEMA LIKE \'' +
+        self.schema + '\'' +
+        ' ORDER BY COLNO';
+    }
+
+    self.execute(columnSQL, function(err, tableInfo) {
       if (err) {
         cb(err);
       } else {
-        var isql = 'SELECT TABNAME, TABSCHEMA, INDNAME, ' +
-          'COLNAMES, UNIQUERULE, FULLKEYCARD ' +
-          'SEQUENTIAL_PAGES, INDEXTYPE, COMPRESSION FROM SYSCAT.INDEXES ' +
-          'WHERE TABNAME LIKE \'' +
-          self.table(model) + '\' ' +
-          'AND TABSCHEMA LIKE \'' +
-          self.schema + '\'';
+        if (self.isDB2z) {
+          indexSQL = 'SELECT TBNAME AS TABNAME, CREATOR AS TABSCHEMA, ' +
+            'NAME AS INDNAME, UNIQUERULE FROM SYSIBM.SYSINDEXES ' +
+            'WHERE TBNAME LIKE \'' + self.table(model) + '\' ' +
+            'AND CREATOR LIKE \'' + self.schema + '\'';
+        } else {
+          indexSQL = 'SELECT TABNAME, TABSCHEMA, INDNAME, ' +
+            'COLNAMES, UNIQUERULE FROM SYSCAT.INDEXES ' +
+            'WHERE TABNAME LIKE \'' +
+            self.table(model) + '\' ' +
+            'AND TABSCHEMA LIKE \'' +
+            self.schema + '\'';
+        }
 
-        self.execute(isql, function(err, indexInfo) {
+        self.execute(indexSQL, function(err, indexInfo) {
           if (err) {
             console.log(err);
           }
@@ -318,8 +346,11 @@ module.exports = function(DB2) {
     // var changes = [];
     async.each(models, function(model, done) {
       self.getTableStatus(model, function(err, fields, indexes) {
+        if (err) {
+          return done(Error(err));
+        }
         // TODO: VALIDATE fields/indexes against model definition
-        done(err);
+        done();
       });
     }, function done(err) {
       if (err) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -28,14 +28,26 @@ function mixinTransaction(DB2, db2) {
       });
     }
 
+    self.connStr += ';IsolationLevel=ReadCommitted';
+
     self.client.open(self.connStr, function(err, connection) {
       if (err) return cb(err);
       connection.beginTransaction(function(err) {
         if (isolationLevel) {
-          var sql = 'SET CURRENT ISOLATION ' + isolationLevel;
-          connection.query(sql, function(err) {
+          var sql;
+          if (self.isDB2z) {
+            // sql = 'CHANGE ISOLATION TO CS'; // + isolationLevel;
+          } else {
+            sql = 'SET CURRENT ISOLATION TO ' + isolationLevel;
+          }
+
+          if (sql) {
+            connection.query(sql, function(err) {
+              cb(err, connection);
+            });
+          } else {
             cb(err, connection);
-          });
+          }
         } else {
           cb(err, connection);
         }

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -12,6 +12,12 @@ before(function() {
 });
 
 describe('discoverModels', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   describe('Discover database schemas', function() {
     it('should return an array of db schemas', function(done) {
       db.connector.discoverDatabaseSchemas(function(err, schemas) {
@@ -91,6 +97,12 @@ describe('discoverModels', function() {
 });
 
 describe('Discover models including other users', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   it('should return an array of all tables and views', function(done) {
 
     db.discoverModelDefinitions({all: true, limit: 3},
@@ -114,6 +126,12 @@ describe('Discover models including other users', function() {
 });
 
 describe('Discover model properties', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   describe('Discover a named model', function() {
     it('should return an array of columns for PRODUCT', function(done) {
       db.discoverModelProperties('PRODUCT', function(err, models) {
@@ -134,6 +152,12 @@ describe('Discover model properties', function() {
 });
 
 describe('Discover model primary keys', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   it('should return an array of primary keys for PRODUCT', function(done) {
     db.discoverPrimaryKeys('PRODUCT', function(err, models) {
       if (err) {
@@ -169,6 +193,12 @@ describe('Discover model primary keys', function() {
 });
 
 describe('Discover model foreign keys', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   it('should return an array of foreign keys for INVENTORY',
     function(done) {
       db.discoverForeignKeys('INVENTORY', function(err, models) {
@@ -205,6 +235,12 @@ describe('Discover model foreign keys', function() {
 });
 
 describe('Discover LDL schema from a table', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   it('should return an LDL schema for INVENTORY',
     function(done) {
       db.discoverSchema('INVENTORY', {owner: config.schema},
@@ -234,6 +270,12 @@ describe('Discover LDL schema from a table', function() {
 });
 
 describe('Discover and build models', function() {
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
+  });
+
   it('should discover and build models',
     function(done) {
       db.discoverAndBuildModels('INVENTORY',

--- a/test/db2.transaction.test.js
+++ b/test/db2.transaction.test.js
@@ -9,86 +9,95 @@ var Transaction = require('loopback-connector').Transaction;
 var db, Post;
 
 describe('transactions', function() {
-
-  before(function(done) {
-    db = global.getDataSource();
-    Post = db.define('PostTX', {
-      title: {type: String, length: 255, index: true},
-      content: {type: String},
-    });
-    db.automigrate('PostTX', done);
+  before(function() {
+    if (global.config.supportDB2z) {
+      this.skip();
+    }
   });
 
-  var currentTx;
-  // Return an async function to start a transaction and create a post
-  function createPostInTx(post) {
-    return function(done) {
-      Transaction.begin(db.connector, Transaction.READ_COMMITTED,
-        function(err, tx) {
-          if (err) return done(err);
-          currentTx = tx;
-          Post.create(post, {transaction: tx},
-            function(err, p) {
-              if (err) {
-                done(err);
-              } else {
-                done();
-              }
-            });
-        });
-    };
-  }
+  describe('commit and rollback', function() {
+    before(function(done) {
 
-  // Return an async function to find matching posts and assert number of
-  // records to equal to the count
-  function expectToFindPosts(where, count, inTx) {
-    return function(done) {
-      var options = {};
-      if (inTx) {
-        options.transaction = currentTx;
-      }
-      Post.find({where: where}, options,
-        function(err, posts) {
-          if (err) return done(err);
-          posts.length.should.be.eql(count);
-          done();
-        });
-    };
-  }
+      db = global.getDataSource();
 
-  describe('commit', function() {
-
-    var post = {title: 't1', content: 'c1'};
-    before(createPostInTx(post));
-
-    it('should not see the uncommitted insert',
-       expectToFindPosts(post, 0));
-
-    it('should see the uncommitted insert from the same transaction',
-      expectToFindPosts(post, 1, true));
-
-    it('should commit a transaction', function(done) {
-      currentTx.commit(done);
+      Post = db.define('PostTX', {
+        title: {type: String, length: 255, index: true},
+        content: {type: String},
+      });
+      db.automigrate('PostTX', done);
     });
 
-    it('should see the committed insert', expectToFindPosts(post, 1));
-  });
+    var currentTx;
+    // Return an async function to start a transaction and create a post
+    function createPostInTx(post) {
+      return function(done) {
+        Transaction.begin(db.connector, Transaction.READ_COMMITTED,
+          function(err, tx) {
+            if (err) return done(err);
+            currentTx = tx;
+            Post.create(post, {transaction: tx},
+              function(err, p) {
+                if (err) {
+                  done(err);
+                } else {
+                  done();
+                }
+              });
+          });
+      };
+    }
 
-  describe('rollback', function() {
+    // Return an async function to find matching posts and assert number of
+    // records to equal to the count
+    function expectToFindPosts(where, count, inTx) {
+      return function(done) {
+        var options = {};
+        if (inTx) {
+          options.transaction = currentTx;
+        }
+        Post.find({where: where}, options,
+          function(err, posts) {
+            if (err) return done(err);
+            posts.length.should.be.eql(count);
+            done();
+          });
+      };
+    }
 
-    var post = {title: 't2', content: 'c2'};
-    before(createPostInTx(post));
+    describe('commit', function() {
 
-    it('should not see the uncommitted insert', expectToFindPosts(post, 0));
+      var post = {title: 't1', content: 'c1'};
+      before(createPostInTx(post));
 
-    it('should see the uncommitted insert from the same transaction',
-      expectToFindPosts(post, 1, true));
+      it('should not see the uncommitted insert',
+         expectToFindPosts(post, 0));
 
-    it('should rollback a transaction', function(done) {
-      currentTx.rollback(done);
+      it('should see the uncommitted insert from the same transaction',
+        expectToFindPosts(post, 1, true));
+
+      it('should commit a transaction', function(done) {
+        currentTx.commit(done);
+      });
+
+      it('should see the committed insert', expectToFindPosts(post, 1));
     });
 
-    it('should not see the rolledback insert', expectToFindPosts(post, 0));
-  });
+    describe('rollback', function() {
 
+      var post = {title: 't2', content: 'c2'};
+      before(createPostInTx(post));
+
+      it('should not see the uncommitted insert',
+        expectToFindPosts(post, 0));
+
+      it('should see the uncommitted insert from the same transaction',
+        expectToFindPosts(post, 1, true));
+
+      it('should rollback a transaction', function(done) {
+        currentTx.rollback(done);
+      });
+
+      it('should not see the rolledback insert', expectToFindPosts(post, 0));
+    });
+  });
 });

--- a/test/init.js
+++ b/test/init.js
@@ -11,6 +11,7 @@ var config = {
   schema: process.env.DB2_SCHEMA || 'STRONGLOOP',
   supportColumnStore: process.env.DB2_USECOLUMNSTORE || false,
   supportDashDB: process.env.DB2_SUPPORT_DASHDB || false,
+  supportDB2z: process.env.DB2_USE_DB2Z || false,
 };
 
 global.config = config;


### PR DESCRIPTION
Adding DB2 z/OS support has resulted in a couple changes to make the code more portable including removal of the MERGE statement that was used in updateOrCreate.  There are some operations that are also now transactional which both simplifies the code and makes it work across the DB2 products.

There is also a small fix to discovery.js for issue #28