### PR TITLE
Lazy connect when app booting from swagger generator

### DIFF
--- a/lib/db2.js
+++ b/lib/db2.js
@@ -168,7 +168,6 @@ DB2.prototype.connect = function(cb) {
     if (err) {
       self.dataSource.connected = false;
       self.dataSource.connecting = false;
-      self.dataSource.emit('error', err);
     } else {
       self.connection = con;
       self.dataSource.connected = true;

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -18,7 +18,15 @@ var Transaction = require('loopback-connector').Transaction;
 exports.initialize = function(ds, cb) {
   ds.connector = new DB2(ds.settings);
   ds.connector.dataSource = ds;
-  if (cb) ds.connector.connect(cb);
+  if (cb) {
+    if (ds.settings.lazyConnect) {
+      process.nextTick(function() {
+        cb();
+      });
+    } else {
+      ds.connector.connect(cb);
+    }
+  }
 };
 
 /**

--- a/test/db2.connection.test.js
+++ b/test/db2.connection.test.js
@@ -50,3 +50,48 @@ function generateDSN(config) {
     ';CurrentSchema=' + config.schema;
   return dsn;
 }
+
+describe('lazyConnect', function() {
+  it('should skip connect phase (lazyConnect = true)', function(done) {
+    var dsConfig = {
+      host: 'invalid-hostname',
+      port: 80,
+      database: 'invalid-database',
+      username: 'invalid-username',
+      password: 'invalid-password',
+      lazyConnect: true,
+    };
+    var ds = getDS(dsConfig);
+
+    var errTimeout = setTimeout(function() {
+      done();
+    }, 2000);
+    ds.on('error', function(err) {
+      clearTimeout(errTimeout);
+      done(err);
+    });
+  });
+
+  it('should report connection error (lazyConnect = false)', function(done) {
+    var dsConfig = {
+      host: 'invalid-hostname',
+      port: 80,
+      database: 'invalid-database',
+      username: 'invalid-username',
+      password: 'invalid-password',
+      lazyConnect: false,
+    };
+    var ds = getDS(dsConfig);
+
+    ds.on('error', function(err) {
+      err.message.should.containEql('[IBM][CLI Driver]');
+      done();
+      process.exit(0);
+    });
+  });
+
+  var getDS = function(config) {
+    var db = new DataSource(require('../'), config);
+    return db;
+  };
+});

--- a/test/db2.connection.test.js
+++ b/test/db2.connection.test.js
@@ -86,7 +86,6 @@ describe('lazyConnect', function() {
     ds.on('error', function(err) {
       err.message.should.containEql('[IBM][CLI Driver]');
       done();
-      process.exit(0);
     });
   });
 


### PR DESCRIPTION
Connect to strongloop/loopback#2242

When booting app from swagger generator, datasources are setup with ds.lazyConnect = true to avoid connection.