### PR TITLE
Use TRIM function to remove whitespace in SQL names

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -44,8 +44,8 @@ function mixinDiscovery(DB2, db2) {
    * @returns {string} sql
    */
   function querySchemas(options) {
-    var sql = 'SELECT definer as "catalog",' +
-      ' TRIM(schemaname) as "schema"' +
+    var sql = 'SELECT definer AS "catalog",' +
+      ' TRIM(schemaname) AS "schema"' +
       ' FROM syscat.schemata';
 
     return paginateSQL(sql, 'schema_name', options);
@@ -65,14 +65,14 @@ function mixinDiscovery(DB2, db2) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
         ' TRIM(tabname) AS "name",' +
         ' TRIM(tabschema) AS "owner",' +
-        ' TRIM(property) as "property"' +
+        ' TRIM(property) AS "property"' +
         ' FROM syscat.tables where substr(property,20,1) NOT LIKE \'Y\'',
         'table_schema, table_name', options);
     } else if (schema) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
         ' TRIM(tabname) AS "name",' +
         ' TRIM(tabschema) AS "schema",' +
-        ' TRIM(property) as "property"' +
+        ' TRIM(property) AS "property"' +
         ' FROM syscat.tables' +
         ' WHERE tabschema=\'' + schema + '\' AND' +
         ' SUBSTR(property, 20, 1) NOT LIKE \'Y\'',
@@ -81,7 +81,7 @@ function mixinDiscovery(DB2, db2) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
         ' TRIM(tabname) AS "name", ' +
         ' TRIM(tabschema) AS "owner",' +
-        ' TRIM(property) as "property" FROM syscat.tables' +
+        ' TRIM(property) AS "property" FROM syscat.tables' +
         ' WHERE tabschema = CURRENT USER AND' +
         ' SUBSTR(property, 20, 1) NOT LIKE \'Y\'',
         'tabname', options);

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -45,7 +45,7 @@ function mixinDiscovery(DB2, db2) {
    */
   function querySchemas(options) {
     var sql = 'SELECT definer as "catalog",' +
-      ' schemaname as "schema"' +
+      ' TRIM(schemaname) as "schema"' +
       ' FROM syscat.schemata';
 
     return paginateSQL(sql, 'schema_name', options);
@@ -63,20 +63,25 @@ function mixinDiscovery(DB2, db2) {
 
     if (options.all && !schema) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
-        ' tabname AS "name", tabschema AS "owner", property as "property"' +
+        ' TRIM(tabname) AS "name",' +
+        ' TRIM(tabschema) AS "owner",' +
+        ' TRIM(property) as "property"' +
         ' FROM syscat.tables where substr(property,20,1) NOT LIKE \'Y\'',
         'table_schema, table_name', options);
     } else if (schema) {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
-        ' tabname AS "name", tabschema AS "schema", property as "property"' +
+        ' TRIM(tabname) AS "name",' +
+        ' TRIM(tabschema) AS "schema",' +
+        ' TRIM(property) as "property"' +
         ' FROM syscat.tables' +
         ' WHERE tabschema=\'' + schema + '\' AND' +
         ' SUBSTR(property, 20, 1) NOT LIKE \'Y\'',
         'table_schema, table_name', options);
     } else {
       sqlTables = paginateSQL('SELECT \'table\' AS "type",' +
-        ' tabname AS "name", ' +
-        ' tabschema AS "owner", property as "property" FROM syscat.tables' +
+        ' TRIM(tabname) AS "name", ' +
+        ' TRIM(tabschema) AS "owner",' +
+        ' TRIM(property) as "property" FROM syscat.tables' +
         ' WHERE tabschema = CURRENT USER AND' +
         ' SUBSTR(property, 20, 1) NOT LIKE \'Y\'',
         'tabname', options);
@@ -99,21 +104,21 @@ function mixinDiscovery(DB2, db2) {
 
       if (options.all && !schema) {
         sqlViews = paginateSQL('SELECT \'view\' AS "type",' +
-          ' tabname AS "name",' +
-          ' tabschema AS "owner"' +
+          ' TRIM(tabname) AS "name",' +
+          ' TRIM(tabschema) AS "owner"' +
           ' FROM syscat.tables',
           'tabschema, tabname', options);
       } else if (schema) {
         sqlViews = paginateSQL('SELECT \'view\' AS "type",' +
-          ' tabname AS "name",' +
-          ' tabschema AS "owner"' +
+          ' TRIM(tabname) AS "name",' +
+          ' TRIM(tabschema) AS "owner"' +
           ' FROM syscat.tables' +
           ' WHERE tabschema=\'' + schema + '\'',
           'tabschema, tabname', options);
       } else {
         sqlViews = paginateSQL('SELECT \'view\' AS "type",' +
-          ' tabname AS "name",' +
-          ' tabschema AS "owner"' +
+          ' TRIM(tabname) AS "name",' +
+          ' TRIM(tabschema) AS "owner"' +
           ' FROM syscat.tables',
           'tabname', options);
       }
@@ -211,12 +216,11 @@ function mixinDiscovery(DB2, db2) {
   function queryColumns(schema, table) {
     var sql = null;
     if (schema) {
-      sql = paginateSQL('SELECT tabschema AS "owner",' +
-        ' tabname AS "tableName",' +
-        ' colname AS "columnName",' +
+      sql = paginateSQL('SELECT TRIM(tabschema) AS "owner",' +
+        ' TRIM(tabname) AS "tableName",' +
+        ' TRIM(colname) AS "columnName",' +
         ' typename AS "dataType",' +
         ' length AS "dataLength",' +
-        // ' numeric_precision AS "dataPrecision",' +
         ' scale AS "dataScale",' +
         ' (CASE WHEN nulls = \'Y\' THEN 1 ELSE 0 END) AS "nullable"' +
         ' FROM syscat.columns' +
@@ -224,12 +228,11 @@ function mixinDiscovery(DB2, db2) {
         (table ? ' AND tabname = \'' + table + '\'' : ''),
         'tabname, colno', {});
     } else {
-      sql = paginateSQL('SELECT tabschema AS "owner",' +
-        ' tabname AS "tableName",' +
-        ' colname AS "columnName",' +
+      sql = paginateSQL('SELECT TRIM(tabschema) AS "owner",' +
+        ' TRIM(tabname) AS "tableName",' +
+        ' TRIM(colname) AS "columnName",' +
         ' typename AS "dataType",' +
         ' length AS "dataLength",' +
-        // ' numeric_precision AS "dataPrecision",' +
         ' scale AS "dataScale",' +
         ' (CASE WHEN nulls = \'Y\' THEN 1 ELSE 0 END) AS "nullable"' +
         ' FROM syscat.columns' +
@@ -285,9 +288,9 @@ function mixinDiscovery(DB2, db2) {
    * @returns {string}
    */
   function queryPrimaryKeys(schema, table) {
-    var sql = 'SELECT tabschema AS "owner",' +
-      ' tabname AS "tableName",' +
-      ' colname AS "columnName",' +
+    var sql = 'SELECT TRIM(tabschema) AS "owner",' +
+      ' TRIM(tabname) AS "tableName",' +
+      ' TRIM(colname) AS "columnName",' +
       ' colseq AS "keySeq",' +
       ' constname AS "pkName"' +
       ' FROM syscat.keycoluse' +
@@ -338,12 +341,12 @@ function mixinDiscovery(DB2, db2) {
    */
   function queryForeignKeys(schema, table) {
     var sql =
-      'SELECT tabschema AS "fkOwner",' +
-      ' constname AS "fkName",' +
-      ' tabname AS "fkTableName",' +
-      ' reftabschema AS "pkOwner", \'PRIMARY\' AS "pkName",' +
-      ' reftabname AS "pkTableName",' +
-      ' refkeyname AS "pkColumnName"' +
+      'SELECT TRIM(tabschema) AS "fkOwner",' +
+      ' TRIM(constname) AS "fkName",' +
+      ' TRIM(tabname) AS "fkTableName",' +
+      ' TRIM(reftabschema) AS "pkOwner", \'PRIMARY\' AS "pkName",' +
+      ' TRIM(reftabname) AS "pkTableName",' +
+      ' TRIM(refkeyname) AS "pkColumnName"' +
       ' FROM syscat.references';
 
     if (schema || table) {
@@ -393,14 +396,14 @@ function mixinDiscovery(DB2, db2) {
    * @returns {string}
    */
   function queryExportedForeignKeys(schema, table) {
-    var sql = 'SELECT a.constraint_name AS "fkName",' +
-      ' a.tabschema AS "fkOwner",' +
-      ' a.tabname AS "fkTableName",' +
-      ' a.colname AS "fkColumnName",' +
+    var sql = 'SELECT TRIM(a.constraint_name) AS "fkName",' +
+      ' TRIM(a.tabschema) AS "fkOwner",' +
+      ' TRIM(a.tabname) AS "fkTableName",' +
+      ' TRIM(a.colname) AS "fkColumnName",' +
       ' NULL AS "pkName",' +
-      ' a.referenced_table_schema AS "pkOwner",' +
-      ' a.referenced_table_name AS "pkTableName",' +
-      ' a.referenced_column_name AS "pkColumnName"' +
+      ' TRIM(a.referenced_table_schema) AS "pkOwner",' +
+      ' TRIM(a.referenced_table_name) AS "pkTableName",' +
+      ' TRIM(a.referenced_column_name) AS "pkColumnName"' +
       ' FROM information_schema.key_column_usage a' +
       ' WHERE a.position_in_unique_constraint IS NOT NULL';
     if (schema) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "pretest": "eslint ./ && jscs ./",
     "lint": "eslint ./ && jscs ./",
-    "test": "mocha --timeout 10000"
+    "test": "mocha --timeout 15000"
   },
   "dependencies": {
     "async": "^1.5.0",

--- a/test/db2.migration.test.js
+++ b/test/db2.migration.test.js
@@ -378,19 +378,23 @@ describe('migrations', function() {
       dateTime: new Date('Aug 9 1996 07:47:33 GMT'),
       timestamp: new Date('Sep 22 2007 17:12:22 GMT'),
     }, function(err, obj) {
-      assert.ok(!err);
-      assert.ok(obj);
-      DateData.findById(obj.id, function(err, found) {
-        if (err) {
-          done(err);
-        } else {
-          assert.equal(found.dateTime.toGMTString(),
-            'Fri, 09 Aug 1996 07:47:33 GMT');
-          assert.equal(found.timestamp.toGMTString(),
-            'Sat, 22 Sep 2007 17:12:22 GMT');
-        }
-        done();
-      });
+      if (err) {
+        done(err);
+      } else {
+        // assert.ok(!err);
+        assert.ok(obj);
+        DateData.findById(obj.id, function(err, found) {
+          if (err) {
+            done(err);
+          } else {
+            assert.equal(found.dateTime.toGMTString(),
+              'Fri, 09 Aug 1996 07:47:33 GMT');
+            assert.equal(found.timestamp.toGMTString(),
+              'Sat, 22 Sep 2007 17:12:22 GMT');
+          }
+          done();
+        });
+      }
     });
   });
 


### PR DESCRIPTION
Many of the discovery functions were pulling contents of columns and ignoring whitespace.  DB2 stores column names, table names, schema names, etc. with white space so using the TRIM function is a safe way to avoid bad comparisons when searching for names in the catalog tables.