### PR TITLE
Stability fixes

### DIFF
--- a/lib/db2.js
+++ b/lib/db2.js
@@ -88,6 +88,8 @@ DB2.prototype.create = function(model, data, options, callback) {
  * @param {Function} cb The callback function
  */
 DB2.prototype.update = function(model, where, data, options, cb) {
+  debug('DB2.prototype.update: model=%j, where=%j, options=%j',
+        model, where, options);
   var self = this;
   var stmt = self.buildUpdate(model, where, data, options);
   var id = self.idName(model);
@@ -108,6 +110,8 @@ DB2.prototype.update = function(model, where, data, options, cb) {
  * @param {Function} cb The callback function
  */
 DB2.prototype.destroyAll = function(model, where, options, cb) {
+  debug('DB2.prototype.destroyAll: model=%j, where=%j, options=%j',
+        model, where, options);
   var self = this;
   var stmt = self.buildDelete(model, where, options);
   var id = self.idName(model);

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -92,8 +92,8 @@ DB2.prototype.update = function(model, where, data, options, cb) {
         model, where, options);
   var self = this;
   var stmt = self.buildUpdate(model, where, data, options);
-  var id = self.idName(model);
-  var sql = 'SELECT \"' + id + '\" FROM FINAL TABLE (' + stmt.sql + ')';
+  var idName = self.idName(model);
+  var sql = 'SELECT \"' + idName + '\" FROM FINAL TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
       cb(err, {count: info.length});
@@ -114,8 +114,8 @@ DB2.prototype.destroyAll = function(model, where, options, cb) {
         model, where, options);
   var self = this;
   var stmt = self.buildDelete(model, where, options);
-  var id = self.idName(model);
-  var sql = 'SELECT \"' + id + '\" FROM OLD TABLE (' + stmt.sql + ')';
+  var idName = self.idName(model);
+  var sql = 'SELECT \"' + idName + '\" FROM OLD TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
       cb(err, {count: info.length});

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -52,15 +52,27 @@ util.inherits(DB2, IBMDB);
  * @param {Function} [callback] The callback function
  */
 DB2.prototype.create = function(model, data, options, callback) {
+  debug('DB2.prototype.create: model=%j, where=%j, options=%j',
+        model, where, options);
   var self = this;
   var stmt = self.buildInsert(model, data, options);
-  var id = self.idName(model);
-  var sql = 'SELECT \"' + id + '\" FROM FINAL TABLE (' + stmt.sql + ')';
+  var idName = self.idName(model);
+  var sql;
+
+  if (!data[idName]) {
+    sql = 'SELECT \"' + idName + '\" FROM FINAL TABLE (' +
+          stmt.sql + ')';
+  } else {
+    sql = stmt.sql;
+  }
+
   self.execute(sql, stmt.params, options, function(err, info) {
     if (err) {
       callback(err);
     } else {
-      callback(err, info[0][id]);
+      if (data[idName]) return callback(err, data[idName]);
+
+      callback(err, info[0][idName]);
     }
   });
 };

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -52,7 +52,7 @@ util.inherits(DB2, IBMDB);
  * @param {Function} [callback] The callback function
  */
 DB2.prototype.create = function(model, data, options, callback) {
-  debug('DB2.prototype.create: model=%j, where=%j, options=%j',
+  debug('DB2.prototype.create: model=%j, data=%j, options=%j',
         model, options);
   var self = this;
   var stmt = self.buildInsert(model, data, options);
@@ -88,8 +88,8 @@ DB2.prototype.create = function(model, data, options, callback) {
  * @param {Function} cb The callback function
  */
 DB2.prototype.update = function(model, where, data, options, cb) {
-  debug('DB2.prototype.update: model=%j, where=%j, options=%j',
-        model, where, options);
+  debug('DB2.prototype.update: model=%j, where=%j, data=%j options=%j',
+        model, where, data, options);
   var self = this;
   var stmt = self.buildUpdate(model, where, data, options);
   var idName = self.idName(model);

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -52,8 +52,8 @@ util.inherits(DB2, IBMDB);
  * @param {Function} [callback] The callback function
  */
 DB2.prototype.create = function(model, data, options, callback) {
-  debug('DB2.prototype.create: model=%j, data=%j, options=%j',
-        model, options);
+  debug('DB2.prototype.create: model=%s, data=%j, options=%j',
+        model, data, options);
   var self = this;
   var stmt = self.buildInsert(model, data, options);
   var idName = self.idName(model);
@@ -88,7 +88,7 @@ DB2.prototype.create = function(model, data, options, callback) {
  * @param {Function} cb The callback function
  */
 DB2.prototype.update = function(model, where, data, options, cb) {
-  debug('DB2.prototype.update: model=%j, where=%j, data=%j options=%j',
+  debug('DB2.prototype.update: model=%s, where=%j, data=%j options=%j',
         model, where, data, options);
   var self = this;
   var stmt = self.buildUpdate(model, where, data, options);
@@ -110,7 +110,7 @@ DB2.prototype.update = function(model, where, data, options, cb) {
  * @param {Function} cb The callback function
  */
 DB2.prototype.destroyAll = function(model, where, options, cb) {
-  debug('DB2.prototype.destroyAll: model=%j, where=%j, options=%j',
+  debug('DB2.prototype.destroyAll: model=%s, where=%j, options=%j',
         model, where, options);
   var self = this;
   var stmt = self.buildDelete(model, where, options);

--- a/lib/db2.js
+++ b/lib/db2.js
@@ -53,7 +53,7 @@ util.inherits(DB2, IBMDB);
  */
 DB2.prototype.create = function(model, data, options, callback) {
   debug('DB2.prototype.create: model=%j, where=%j, options=%j',
-        model, where, options);
+        model, options);
   var self = this;
   var stmt = self.buildInsert(model, data, options);
   var idName = self.idName(model);


### PR DESCRIPTION
There are 3 commits here.  First is the core of the change which updates the create function to only call UPDATE instead of SELECT .. FROM FINAL if the data passed in contains the ID column data already.  The reason for doing this is that a SELECT ... FROM FINAL will not properly handle this case and it isn't needed anyway as the data was passed in.  Also, it saves execution time on the server as it doesn't need to execute an atomic update and query.

The second commit adds debug statements and the third fixes a linting error.