### PR TITLE
Change idName to idColumn

### DIFF
--- a/lib/db2.js
+++ b/lib/db2.js
@@ -56,7 +56,7 @@ DB2.prototype.create = function(model, data, options, callback) {
         model, data, options);
   var self = this;
   var stmt = self.buildInsert(model, data, options);
-  var idName = self.idName(model);
+  var idName = self.idColumn(model);
   var sql;
 
   if (!data[idName]) {
@@ -92,7 +92,7 @@ DB2.prototype.update = function(model, where, data, options, cb) {
         model, where, data, options);
   var self = this;
   var stmt = self.buildUpdate(model, where, data, options);
-  var idName = self.idName(model);
+  var idName = self.idColumn(model);
   var sql = 'SELECT \"' + idName + '\" FROM FINAL TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
@@ -114,7 +114,7 @@ DB2.prototype.destroyAll = function(model, where, options, cb) {
         model, where, options);
   var self = this;
   var stmt = self.buildDelete(model, where, options);
-  var idName = self.idName(model);
+  var idName = self.idColumn(model);
   var sql = 'SELECT \"' + idName + '\" FROM OLD TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {


### PR DESCRIPTION
Fixes https://github.com/strongloop/loopback-connector-db2/issues/45 by changing the call from self.idName to self.idColumn to properly locate the column name of the ID column for the Select statements used.