### PR TITLE
Increase timeout to fix failing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --timeout 15000",
+    "test": "mocha --timeout 20000",
     "posttest": "npm run lint"
   },
   "dependencies": {


### PR DESCRIPTION
Lock is not releasing in DB in time for the test to complete as per
@qpresley. Trying this as a workaround.

cc @qpresley @strongloop/fa-db-connectors 