### PR TITLE
Use setIsolationLevel

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -11,6 +11,27 @@ var Transaction = require('loopback-connector').Transaction;
 
 module.exports = mixinTransaction;
 
+var mapIsolationLevel = function(isolationLevelString) {
+  var ret = 2;
+  switch (isolationLevelString) {
+    case Transaction.READ_UNCOMMITTED:
+      ret = 1;
+      break;
+    case Transaction.SERIALIZABLE:
+      ret = 4;
+      break;
+    case Transaction.REPEATABLE_READ:
+      ret = 8;
+      break;
+    case Transaction.READ_COMMITTED:
+    default:
+      ret = 2;
+      break;
+  }
+
+  return ret;
+};
+
 /*!
  * @param {DB2} DB2 connector class
  */
@@ -26,34 +47,14 @@ function mixinTransaction(DB2, db2) {
 
     var self = this;
 
-    if (isolationLevel !== Transaction.READ_COMMITTED &&
-        isolationLevel !== Transaction.SERIALIZABLE) {
-      var err = new Error(g.f('Invalid {{isolationLevel}}: %s',
-            isolationLevel));
-      err.statusCode = 400;
-      return process.nextTick(function() {
-        cb(err);
-      });
-    }
-
-    self.connStr += ';IsolationLevel=ReadCommitted';
-
     self.client.open(self.connStr, function(err, connection) {
       if (err) return cb(err);
       connection.beginTransaction(function(err) {
         if (isolationLevel) {
-          var sql = 'SET CURRENT ISOLATION TO ' + isolationLevel;
-
-          if (sql) {
-            connection.query(sql, function(err) {
-              cb(err, connection);
-            });
-          } else {
-            cb(err, connection);
-          }
-        } else {
-          cb(err, connection);
+          connection.setIsolationLevel(mapIsolationLevel(isolationLevel));
         }
+
+        cb(err, connection);
       });
     });
   };


### PR DESCRIPTION
The setIsolationLevel function was recently added to node-ibm_db.  Making use of this cleans the code up and allows connection pooling to work more effectively as it no longer distinguishes between connections strings containing an IsolationLevel tag and those that don't.

@Amir-61 @jannyHou  PTAL