### PR TITLE
Update only return count when forceReturnAffected

### DIFF
--- a/lib/db2.js
+++ b/lib/db2.js
@@ -86,9 +86,15 @@ DB2.prototype.update = function(model, where, data, options, cb) {
   debug('DB2.prototype.update: model=%s, where=%j, data=%j options=%j',
         model, where, data, options);
   var self = this;
+  // stmt.sql will only do update without returning count
   var stmt = self.buildUpdate(model, where, data, options);
   var idName = self.idColumn(model);
-  var sql = 'SELECT \"' + idName + '\" FROM FINAL TABLE (' + stmt.sql + ')';
+
+  var modelDef = self.getModelDefinition(model);
+  var forceReturnAffected = modelDef.settings.forceReturnAffected;
+  var returnAffectedSql = 'SELECT \"' + idName + '\" FROM FINAL TABLE (' + stmt.sql + ')';
+  var sql = forceReturnAffected ? returnAffectedSql : stmt.sql;
+ 
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
       cb(err, {count: info.length});


### PR DESCRIPTION
Related issue: https://github.com/strongloop/loopback-connector/issues/71
Scenario to be fixed in this pr:
In `DB2.prototype.update`, when the [sql](https://github.com/strongloop/loopback-connector-db2/blob/393ad3526be05c111cac5bef30f7d37b4dd2482e/lib/db2.js#L91) selects items from final updated table, transaction might run into deadlock, but a single update sql won't, and `updateAttribute` doesn't actually need `count` returned, a single update sql is enough.

This pr is a short-term solution/workaround according to what Ritchie suggested in slack:
> So if in juggler and core we allow `app.Model.settings.forceReturnAffected = false`

With the fix, user can turn on/off a flag called `forceReturnAffected` in `model.json`:
```json
{
  "name": "customers",
  "base": "PersistedModel",
  "options": {
    "forceReturnAffected": false/true
  }
 ...
}
``` 
- forceReturnAffected: false
  - udpate/updateAttributes/udpateAll will always return the `count` as 0
- forceReturnAffected: true
  - udpate/updateAttributes/udpateAll will return `count` as the actual affected instance#
