### PR TITLE
fixed discoverForeignKeys issue 

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -242,10 +242,10 @@ function mixinDiscovery(DB2, db2) {
     if (schema || table) {
       sql += ' WHERE';
       if (schema) {
-        sql += ' tabschema LIKE \'' + schema + '\'';
+        sql += ' tabschema = \'' + schema + '\'';
       }
       if (table) {
-        sql += ' AND tabname LIKE \'"' + table + '\'';
+        sql += ' AND tabname LIKE \'' + table + '\'';
       }
     }
 


### PR DESCRIPTION
Made some corrections in the query that gets formed for discoverForeignkeys call.

### Description
Following code changes were done:
1. Removed a double quotes symbol that was getting appended with the table name in buildQueryForeignKeys method.
2. Used equality operator instead of LIKE operator for schema name comparison in buildQueryForeignKeys method.

#### Related issues
#97 
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist
<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
