### PR TITLE
Fix for Issue # 99 (buildQueryPrimaryKeys () does not return Primary key details for DB2 database)

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -208,7 +208,7 @@ function mixinDiscovery(DB2, db2) {
       ' colseq AS "keySeq",' +
       ' constname AS "pkName"' +
       ' FROM syscat.keycoluse' +
-      ' WHERE constname = \'PRIMARY\'';
+      ' WHERE colseq IS NOT NULL AND colseq > 0';
 
     if (schema) {
       sql += ' AND tabschema = \'' + schema + '\'';

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -198,7 +198,7 @@ describe('Discover model primary keys', function() {
           }
         });
     });
-    it('should return an array of primary keys for STRONGLOOP.CUSTOMER',
+  it('should return an array of primary keys for STRONGLOOP.CUSTOMER',
       function(done) {
         db.discoverPrimaryKeys('CUSTOMER',
           {owner: config.schema},
@@ -216,7 +216,7 @@ describe('Discover model primary keys', function() {
             }
           });
       });
-    it('should return an array of primary keys for LOCATION',
+  it('should return an array of primary keys for LOCATION',
       function(done) {
         db.discoverPrimaryKeys('LOCATION',
           function(err, models) {
@@ -228,8 +228,8 @@ describe('Discover model primary keys', function() {
                 assert(m.tableName === 'LOCATION');
                 assert(m.pkName !== null);
                 assert(m.columnName === 'ID');
-                  });
-               done(null, models);
+              });
+              done(null, models);
             }
           });
       });
@@ -322,9 +322,9 @@ describe('Discover and build models', function() {
   it('should discover and build models',
     function(done) {
       db.discoverAndBuildModels('INVENTORY',
-                                {owner: config.schema,
-                                 visited: {},
-                                 associations: true},
+        {owner: config.schema,
+          visited: {},
+          associations: true},
         function(err, models) {
           if (err) {
             done();

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -167,7 +167,6 @@ describe('Discover model primary keys', function() {
   it('should return an array of primary keys for PRODUCT', function(done) {
     db.discoverPrimaryKeys('PRODUCT', function(err, models) {
       if (err) {
-        console.error(err);
         done(err);
       } else {
         models.forEach(function(m) {
@@ -186,7 +185,6 @@ describe('Discover model primary keys', function() {
         {owner: config.schema},
         function(err, models) {
           if (err) {
-            console.error(err);
             done(err);
           } else {
             models.forEach(function(m) {
@@ -204,7 +202,6 @@ describe('Discover model primary keys', function() {
           {owner: config.schema},
           function(err, models) {
             if (err) {
-              console.error(err);
               done(err);
             } else {
               models.forEach(function(m) {
@@ -221,7 +218,6 @@ describe('Discover model primary keys', function() {
         db.discoverPrimaryKeys('LOCATION',
           function(err, models) {
             if (err) {
-              console.error(err);
               done(err);
             } else {
               models.forEach(function(m) {

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -171,7 +171,6 @@ describe('Discover model primary keys', function() {
         done(err);
       } else {
         models.forEach(function(m) {
-          // console.dir(m);
           assert(m.tableName === 'PRODUCT');
           assert(m.pkName !== null);
           assert(m.columnName === 'ID');
@@ -191,7 +190,6 @@ describe('Discover model primary keys', function() {
             done(err);
           } else {
             models.forEach(function(m) {
-              // console.dir(m);
               assert(m.tableName === 'PRODUCT');
               assert(m.pkName !== null);
               assert(m.columnName === 'ID');
@@ -210,7 +208,6 @@ describe('Discover model primary keys', function() {
               done(err);
             } else {
               models.forEach(function(m) {
-                // console.dir(m);
                 assert(m.tableName === 'CUSTOMER');
                 assert(m.pkName !== null);
                 assert(m.columnName === 'ID');
@@ -228,7 +225,6 @@ describe('Discover model primary keys', function() {
               done(err);
             } else {
               models.forEach(function(m) {
-                // console.dir(m);
                 assert(m.tableName === 'LOCATION');
                 assert(m.pkName !== null);
                 assert(m.columnName === 'ID');

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -173,6 +173,8 @@ describe('Discover model primary keys', function() {
         models.forEach(function(m) {
           // console.dir(m);
           assert(m.tableName === 'PRODUCT');
+          assert(m.pkName !== null);
+          assert(m.columnName === 'ID');
         });
         done(null, models);
       }
@@ -191,6 +193,8 @@ describe('Discover model primary keys', function() {
             models.forEach(function(m) {
               // console.dir(m);
               assert(m.tableName === 'PRODUCT');
+              assert(m.pkName !== null);
+              assert(m.columnName === 'ID');
             });
             done(null, models);
           }
@@ -208,6 +212,8 @@ describe('Discover model primary keys', function() {
               models.forEach(function(m) {
                 // console.dir(m);
                 assert(m.tableName === 'CUSTOMER');
+                assert(m.pkName !== null);
+                assert(m.columnName === 'ID');
               });
               done(null, models);
             }
@@ -224,8 +230,10 @@ describe('Discover model primary keys', function() {
               models.forEach(function(m) {
                 // console.dir(m);
                 assert(m.tableName === 'LOCATION');
+                assert(m.pkName !== null);
+                assert(m.columnName === 'ID');
                   });
-                  done(null, models);
+               done(null, models);
             }
           });
       });

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -196,6 +196,39 @@ describe('Discover model primary keys', function() {
           }
         });
     });
+    it('should return an array of primary keys for STRONGLOOP.CUSTOMER',
+      function(done) {
+        db.discoverPrimaryKeys('CUSTOMER',
+          {owner: config.schema},
+          function(err, models) {
+            if (err) {
+              console.error(err);
+              done(err);
+            } else {
+              models.forEach(function(m) {
+                // console.dir(m);
+                assert(m.tableName === 'CUSTOMER');
+              });
+              done(null, models);
+            }
+          });
+      });
+    it('should return an array of primary keys for LOCATION',
+      function(done) {
+        db.discoverPrimaryKeys('LOCATION',
+          function(err, models) {
+            if (err) {
+              console.error(err);
+              done(err);
+            } else {
+              models.forEach(function(m) {
+                // console.dir(m);
+                assert(m.tableName === 'LOCATION');
+                  });
+                  done(null, models);
+            }
+          });
+      });
 });
 
 describe('Discover model foreign keys', function() {


### PR DESCRIPTION
### Description

Changed the query which was used to fetch the primary key details.

- Removed "constname = 'PRIMARY'" clause.
- Added new clauses  colseq IS NOT NULL AND colseq > 0 in order to fetch primary key details.

#### Related issues
connect to https://github.com/strongloop/loopback-connector-db2/issues/99

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
