### PR TITLE
fixed issue for missing relations data in discoverSchemas response

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -242,10 +242,10 @@ function mixinDiscovery(DB2, db2) {
     if (schema || table) {
       sql += ' WHERE';
       if (schema) {
-        sql += ' tabschema LIKE \'' + schema + '\'';
+        sql += ' tabschema = \'' + schema + '\'';
       }
       if (table) {
-        sql += ' AND tabname LIKE \'"' + table + '\'';
+        sql += ' AND tabname LIKE \'' + table + '\'';
       }
     }
 

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -247,9 +247,9 @@ describe('Discover model foreign keys', function() {
           if (err) {
             done(err);
           } else {
-             var fkNames = ['RESERVATION_CUSTOMER_FK', 'RESERVATION_LOCATION_FK',
+            var fkNames = ['RESERVATION_CUSTOMER_FK', 'RESERVATION_LOCATION_FK',
               'RESERVATION_PRODUCT_FK'];
-              var areFKInvalid = false;
+            var areFKInvalid = false;
             models.forEach(function(m) {
               assert(m.fkTableName === 'RESERVATION');
               if (!(fkNames.indexOf(m.fkName) > -1)) {
@@ -308,9 +308,9 @@ describe('Discover and build models', function() {
   it('should discover and build models',
     function(done) {
       db.discoverAndBuildModels('INVENTORY',
-                                {owner: config.schema,
-                                 visited: {},
-                                 associations: true},
+        {owner: config.schema,
+          visited: {},
+          associations: true},
         function(err, models) {
           if (err) {
             done();

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -245,14 +245,18 @@ describe('Discover model foreign keys', function() {
       },
         function(err, models) {
           if (err) {
-            console.error(err);
             done(err);
           } else {
+             var fkNames = ['RESERVATION_CUSTOMER_FK', 'RESERVATION_LOCATION_FK',
+              'RESERVATION_PRODUCT_FK'];
+              var areFKInvalid = false;
             models.forEach(function(m) {
-              // console.dir(m);
-              console.log(m);
               assert(m.fkTableName === 'RESERVATION');
+              if (!(fkNames.indexOf(m.fkName) > -1)) {
+                areFKInvalid = true;
+              }
             });
+            assert(areFKInvalid === false);
             done(null, models);
           }
         });

--- a/test/db2.discover.test.js
+++ b/test/db2.discover.test.js
@@ -238,6 +238,25 @@ describe('Discover model foreign keys', function() {
           }
         });
     });
+  it('should return an array of foreign keys for STRONGLOOP.RESERVATION',
+    function(done) {
+      db.discoverForeignKeys('RESERVATION', {
+        owner: config.schema,
+      },
+        function(err, models) {
+          if (err) {
+            console.error(err);
+            done(err);
+          } else {
+            models.forEach(function(m) {
+              // console.dir(m);
+              console.log(m);
+              assert(m.fkTableName === 'RESERVATION');
+            });
+            done(null, models);
+          }
+        });
+    });
 });
 
 describe('Discover LDL schema from a table', function() {


### PR DESCRIPTION
Made some corrections in the query that gets formed for discoverForeignkeys call.

### Description
Following code changes were done:
1. Removed a double quotes symbol that was getting appended with the table name in buildQueryForeignKeys method.
2. Used equality operator instead of LIKE operator for schema name comparison in buildQueryForeignKeys method.

Note- There is no valid reason for why using LIKE operator for schema name comparison gives empty response. But using **=** instead of **LIKE** operator returns the expected response for discoverForeignKeys call.

#### Related issues
connect to #97 
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist
<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
