### PR TITLE
drop support for node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.2",
   "description": "LoopBack Connector for IBM DB2",
   "engines": {
-    "node": ">=6"
+    "node": ">=8.9"
   },
   "keywords": [
     "IBM",


### PR DESCRIPTION
### Description
Drop support for Node.js 6 and see if CI is green for Node 12

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/3110

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
