### PR TITLE
fix: catch error properly for deleteall

### DIFF
--- a/lib/db2.js
+++ b/lib/db2.js
@@ -91,7 +91,11 @@ DB2.prototype.update = function(model, where, data, options, cb) {
             'FROM FINAL TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
-      cb(err, {count: Number.parseInt(info[0].affectedRows, 10)});
+      if (!err && info && info.length > 0) {
+        var count = Number.parseInt(info[0].affectedRows, 10);
+        return cb(null, {count: count});
+      }
+      cb(err);
     }
   });
 };
@@ -114,7 +118,11 @@ DB2.prototype.destroyAll = function(model, where, options, cb) {
             'FROM OLD TABLE (' + stmt.sql + ')';
   self.execute(sql, stmt.params, options, function(err, info) {
     if (cb) {
-      cb(err, {count: Number.parseInt(info[0].affectedRows, 10)});
+      if (!err && info && info.length > 0) {
+        var count = Number.parseInt(info[0].affectedRows, 10);
+        return cb(null, {count: count});
+      }
+      cb(err);
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
+    "lint:fix": "npm run lint -- --fix",
     "pretest": "node pretest.js",
     "test": "mocha --timeout 60000 test/*.test.js node_modules/juggler-v3/test.js node_modules/juggler-v4/test.js",
     "posttest": "npm run lint"


### PR DESCRIPTION
Moved the description here:

> When the SQL returnes a warning, there is a non-null err and the info is an empty array so `info[o].affectedRows` blows up

This PR is created to fix ^
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-db2) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
